### PR TITLE
serializeItem method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changes
 - correctly pull in parent app configuration
+- add `item-service.serializeItem(item)` internal function that will correctly serialize an item for POSTing to the item apis via jQuery
 
 ## [0.2.4]
 ### Added

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -5,10 +5,12 @@ export default Ember.Service.extend(serviceMixin,{
 
   getPortalRestUrl(){
     let portalBaseUrl = 'https://www.arcgis.com';
+
     //check for and use the url configured in the host app
     if(this.get('hostAppConfig.APP.portalBaseUrl')){
       portalBaseUrl = this.get('hostAppConfig.APP.portalBaseUrl');
     }
+    console.debug('Item Service portalBaseUrl: ' + portalBaseUrl);
     return portalBaseUrl + '/sharing/rest';
   },
   /**
@@ -73,13 +75,29 @@ export default Ember.Service.extend(serviceMixin,{
   },
 
   /**
+   * Extra logic to transform the item prior to POSTing it
+   */
+  _serializeItem(item){
+    let clone = Ember.copy(item, true);
+    //Array items need to become comma delim strings
+    if(clone.typeKeywords){
+      clone.typeKeywords = item.typeKeywords.join(', ');
+    }
+    if(clone.tags){
+      clone.tags = item.tags.join(', ');
+    }
+    return clone;
+  },
+  /**
    * Shared logic for POST operations
    */
   _post(url, item){
-    let form = this.encodeForm(item);
+
+    let serializedItem = this._serializeItem(item);
+
     let options = {
       method:'POST',
-      data: form
+      data: serializedItem
     };
     return this.request(url, options);
   },


### PR DESCRIPTION
This handles converting some of the `['string1','string2']` properties into `"string1, string2"` because that's what the AGO API wants.
