### PR TITLE
remove ENV.APP.arcgisPortal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+## [0.7.0]
+### Changed
+- relies on `session.portalHostName` instead of `ENV.APP.arcgisPortal.*`. This makes configuration more consistent and removes duplication urls in the app config file.
 
 ## [0.6.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ After adding this to your project, you will have a number of services available 
 
 ## Dependencies
 This project is now using `ember-network/fetch` to enable fastboot compatibility. Please also `ember install ember-network`
+- `torii-provider-arcgis` install via `npm i torii-provider-arcgis`
 
 ### Shared Methods
 All the services expose a set of shared helper properties and methods:
@@ -81,20 +82,19 @@ All the services expose a set of shared helper properties and methods:
 
 ### environment.js
 
-You need to add a section in the `.APP` hash to add `arcgisPortal` details
+Configuration for how to connect to the portal is managed in the `torii` section. If you are using ArcGIS Online, the `portalUrl` property is not needed.
 ```
 // environment.js
 ...
-APP: {
-  // portalBaseUrl is still needed
-  portalBaseUrl: 'https://qaext.arcgis.com',
-  // this new hash is what we are transitioning to
-  arcgisPortal: {
-    domain: 'arcgis.com',
-    env: 'www',
-    maps: 'maps',
-  },
-},
+torii: {
+  sessionServiceName: 'session',
+  providers: {
+    'arcgis-oauth-bearer': {
+      apiKey: 'SECRET-KEY-FOR-YOUR-APP',
+      portalUrl: 'https://yourawesomeportal.com'
+    }
+  }
+}
 ...
 ```
 

--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -15,27 +15,17 @@ export default Ember.Mixin.create({
   /**
    * Return the ArcGIS Portal Rest base url
    */
-  portalRestUrl: Ember.computed('hostAppConfig.APP.portalBaseUrl', function () {
+  portalRestUrl: Ember.computed('session.portalHostName', function () {
     let baseUrl = this.get('portalUrl');
     return baseUrl + '/sharing/rest';
   }),
 
   /**
    * Return the ArcGIS Portal base url (for visiting pages etc)
+   * Defaults to https because there is no negative to using it
    */
-  portalUrl: Ember.computed('hostAppConfig.APP.arcgisPortal', function () {
-    let url = '';
-    if (this.get('session.isAuthenticated')) {
-      // delegate to session service
-      url = `https://${this.get('session.orgPortalUrl')}`;
-    } else {
-      const domain = this.get('hostAppConfig.APP.arcgisPortal.domain') || 'arcgis.com';
-      const subdomain = this.get('hostAppConfig.APP.arcgisPortal.env') || 'www';
-      url = `https://${subdomain}.${domain}`;
-    }
-    // Ember.debug('Portal Url: ' + url);
-
-    return url;
+  portalUrl: Ember.computed('session.portalHostName', function () {
+    return 'https://' + this.get('session.portalHostName');
   }),
 
   encodeForm (form = {}) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">= 0.10.0"
   },
   "author": "Dave Bouwman <dbouwman@esri.com>",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-cli": "2.8.0",
@@ -47,7 +47,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "jsoneditor": "5.5.6",
     "loader.js": "^4.0.1",
-    "torii-provider-arcgis": "0.3.1"
+    "torii-provider-arcgis": "0.4.1"
   },
   "keywords": [
     "ember-addon"

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -14,25 +14,26 @@ module.exports = function (environment) {
     },
 
     APP: {
-      portalBaseUrl: 'https://qaext.arcgis.com',
-      arcgisPortal: {
-        domain: 'arcgis.com',
-        env: 'qaext',
-        maps: 'mapsqa',
-      },
+      // portalBaseUrl: 'https://qaext.arcgis.com',
+      // arcgisPortal: {
+      //   domain: 'arcgis.com',
+      //   env: 'qaext',
+      //   maps: 'mapsqa',
+      // },
     },
     torii: {
       sessionServiceName: 'session',
       providers: {
         'arcgis-oauth-bearer': {
          // apiKey: 'x3u9xkfpYyYbJu08' // production
-          apiKey: 'VpiQwiuWl7KMTGys' // qaext
+          apiKey: 'VpiQwiuWl7KMTGys', // qaext
+          portalUrl: 'https://qaext.arcgis.com'
         }
       }
     }
   };
 
-  ENV.torii.providers['arcgis-oauth-bearer'].portalUrl = ENV.APP.portalBaseUrl;
+  // ENV.torii.providers['arcgis-oauth-bearer'].portalUrl = ENV.APP.portalBaseUrl;
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;


### PR DESCRIPTION
Now relies on `session.portalHostName` instead of `ENV.APP.arcgisPortal.*`. This makes configuration more consistent and removes duplication urls in the app config file.