### PR TITLE
change `isDevelopingAddon` to return false

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@
 module.exports = {
   name: 'ember-arcgis-portal-services',
   isDevelopingAddon: function() {
-    return true;
+    return false;
   }
 };


### PR DESCRIPTION
...so that the eslint configs in this addon (standard, semistandard) aren't required for any project that uses it. addresses #46. 