### PR TITLE
Use token from portalOpts even if undefined

### DIFF
--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -75,7 +75,7 @@ export default Ember.Mixin.create({
   /**
    * Fetch based request method
    */
-  request (urlPath, options, portalOpts = {}) {
+  request (urlPath, options, portalOpts) {
     let opts = options || {};
     let url = `${this.getPortalRestUrl(portalOpts)}${urlPath}`;
 
@@ -101,7 +101,9 @@ export default Ember.Mixin.create({
     }
 
     // append in the token
-    const token = portalOpts.token || this.get('session.token');
+    // if portalOpts was provided use it even if it is undefined
+    // this is so we can make unauthenticated requests by passing portalOpts without a token
+    const token = portalOpts ? portalOpts.token : this.get('session.token');
     if (token) {
       // add a token
       if (url.indexOf('?') > -1) {

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -8,17 +8,17 @@ export default Ember.Service.extend(serviceMixin, {
   /**
    * User Search
    */
-  search (form, portalOpts = {}) {
+  search (form, portalOpts) {
     Ember.deprecate('use .searchPortalUsers(...) or .searchCommunityUsers(...)', false, {id: 'searchDeprecation', until: '10.0.0'});
 
-    if (this.get('session.isAuthenticated') || portalOpts.portalHostname) {
+    if (this.get('session.isAuthenticated') || (portalOpts && portalOpts.portalHostname)) {
       return this.searchPortalUsers(...arguments);
     } else {
       return this.searchCommunityUsers(...arguments);
     }
   },
 
-  searchPortalUsers (form, portalOpts = {}) {
+  searchPortalUsers (form, portalOpts) {
     // all users in the org
     // q is ignored!
     // but you can do things like firstname=
@@ -27,7 +27,7 @@ export default Ember.Service.extend(serviceMixin, {
     return this.request(urlPath, null, portalOpts);
   },
 
-  searchCommunityUsers (form, portalOpts = {}) {
+  searchCommunityUsers (form, portalOpts) {
     // all users in the portal
     // q works and you can do q=orgid:...
     // but you get less info than with allUsers


### PR DESCRIPTION
We now use the `token` property of `portalOpts` if `portalOpts` was provided, even if it is `undefined`. This is so we can make unauthenticated requests to the portal specified on `portalOpts`.

This is necessary because of desired changes in opendata-admin. We now want to show some community org info without the admin logging in to the community org.