### PR TITLE
get back 1000 resources at a time

### DIFF
--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -132,7 +132,7 @@ export default Ember.Service.extend(serviceMixin, {
    * Get the resources associated with an Item
    */
   getResources (itemId, portalOpts) {
-    const urlPath = `/content/items/${itemId}/resources?f=json`;
+    const urlPath = `/content/items/${itemId}/resources?f=json&num=1000`;
     return this.request(urlPath, null, portalOpts);
   },
 


### PR DESCRIPTION
there's no limit on how many resources portal will return, so we've been using `num=1000` to get them all at once (assuming 1000 is a reasonable upper limit). seems silly to get 10 at a time, or even 100 at a time, when each record only consists of a filename and a date. 