### PR TITLE
stop sending null params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+
+## 0.24.1
+### Changed
+- `service-mixin::encodeForm` no longer sends field for null properties, thus avoiding `"null"` values in items
+
 ## 0.24.0
 ### Added
 - `groups-service` `ensureUniqueGroupName` & `doesGroupExist` methods

--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -68,14 +68,12 @@ export default Ember.Mixin.create({
   encodeForm (form = {}) {
     if (typeof form === 'string') { return form; }
 
-    // Ember.merge(form, this.get('defaultParams'));
-    return Object.keys(form).map((key) => {
-      // don't convert null props into fields
-      // https://github.com/emberjs/ember.js/blob/3b60016c2b6b38646d954014d10f74fcfe1a3d54/packages/ember-runtime/lib/core.js#L82-84
+    return Object.keys(form).reduce((acc, key) => {
       if (!Ember.isNone(form[key])) {
-        return [key, form[key]].map(encodeURIComponent).join('=');
+        acc.push([key, form[key]].map(encodeURIComponent).join('='));
       }
-    }).join('&');
+      return acc;
+    }, []).join('&');
   },
 
   /**

--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -70,7 +70,11 @@ export default Ember.Mixin.create({
 
     // Ember.merge(form, this.get('defaultParams'));
     return Object.keys(form).map((key) => {
-      return [key, form[key]].map(encodeURIComponent).join('=');
+      // don't convert null props into fields
+      // https://github.com/emberjs/ember.js/blob/3b60016c2b6b38646d954014d10f74fcfe1a3d54/packages/ember-runtime/lib/core.js#L82-84
+      if (!Ember.isNone(form[key])) {
+        return [key, form[key]].map(encodeURIComponent).join('=');
+      }
     }).join('&');
   },
 

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -233,6 +233,10 @@ export default Ember.Service.extend(serviceMixin, {
     if (clone.properties) {
       clone.properties = JSON.stringify(clone.properties);
     }
+
+    if (clone.serviceProxyParams) {
+      clone.serviceProxyParams = JSON.stringify(clone.serviceProxyParams);
+    }
     return clone;
   },
   /**

--- a/tests/dummy/app/items/item/edit/route.js
+++ b/tests/dummy/app/items/item/edit/route.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
     Ember.debug('Items.item.edit id: ' + params.id + ' item.id ' + item.id + JSON.stringify(params));
 
     // only get the data if this is a type with data!
-    let validTypes = ['Web Mapping Application', 'Web Map', 'Hub Site Application', 'Hub Page', 'Hub Initiative', 'Map Service'];
+    let validTypes = ['Web Mapping Application', 'Web Map', 'Dashboard', 'Hub Site Application', 'Hub Page', 'Hub Initiative', 'Map Service'];
     if (validTypes.includes(item.type)) {
       return Ember.RSVP.hash({
         item: item,

--- a/tests/unit/mixins/service-mixin-test.js
+++ b/tests/unit/mixins/service-mixin-test.js
@@ -11,3 +11,26 @@ test('fixing a jacked up portal url', function (assert) {
   const url = subject.fixUrl('https://LINUX1.ESRI.COM:7080/arcgis', {httpsPort: 7443}, 'https:');
   assert.equal(url, 'https://linux1.esri.com:7443/arcgis');
 });
+
+test('drop nulls from form when encoding', function (assert) {
+  let ServiceMixinObject = Ember.Object.extend(ServiceMixinMixin);
+  let subject = ServiceMixinObject.create();
+  let form = {
+    title: 'a string',
+    properties: JSON.stringify({
+      key: 'value'
+    }),
+    tags: ['a', 'series', 'of', 'strings'],
+    typeKeywords: [],
+    falseyProp: false,
+    truthyProp: true,
+    nullyProp: null
+  };
+  const encoded = subject.encodeForm(form);
+  assert.equal(encoded.includes('nully'), false, 'nullyProp should not be included');
+  assert.ok(encoded.includes('tags'), 'tags should be included');
+  assert.ok(encoded.includes('falseyProp'), 'falseyProp should be included');
+  assert.ok(encoded.includes('truthyProp'), 'truthyProp should be included');
+  assert.ok(encoded.includes('typeKeywords'), 'typeKeywords should be included');
+  assert.ok(encoded.includes('properties'), 'properties should be included');
+});

--- a/tests/unit/mixins/service-mixin-test.js
+++ b/tests/unit/mixins/service-mixin-test.js
@@ -12,6 +12,13 @@ test('fixing a jacked up portal url', function (assert) {
   assert.equal(url, 'https://linux1.esri.com:7443/arcgis');
 });
 
+function includes (str, target) {
+  let included = false;
+  if (str.indexOf(target) > -1) {
+    included = true;
+  }
+  return included;
+}
 test('drop nulls from form when encoding', function (assert) {
   let ServiceMixinObject = Ember.Object.extend(ServiceMixinMixin);
   let subject = ServiceMixinObject.create();
@@ -27,10 +34,11 @@ test('drop nulls from form when encoding', function (assert) {
     nullyProp: null
   };
   const encoded = subject.encodeForm(form);
-  assert.equal(encoded.includes('nully'), false, 'nullyProp should not be included');
-  assert.ok(encoded.includes('tags'), 'tags should be included');
-  assert.ok(encoded.includes('falseyProp'), 'falseyProp should be included');
-  assert.ok(encoded.includes('truthyProp'), 'truthyProp should be included');
-  assert.ok(encoded.includes('typeKeywords'), 'typeKeywords should be included');
-  assert.ok(encoded.includes('properties'), 'properties should be included');
+  // had been using .includes in the tests, but that would fail in phantom...
+  assert.notOk(includes(encoded, 'nully'), 'nullyProp should not be included');
+  assert.ok(includes(encoded, 'tags'), 'tags should be included');
+  assert.ok(includes(encoded, 'falseyProp'), 'falseyProp should be included');
+  assert.ok(includes(encoded, 'truthyProp'), 'truthyProp should be included');
+  assert.ok(includes(encoded, 'typeKeywords'), 'typeKeywords should be included');
+  assert.ok(includes(encoded, 'properties'), 'properties should be included');
 });


### PR DESCRIPTION
Currently we encode a null property into `&prop=null` which the AGO api dutifully turns into `"null"`

This will eliminate the sending of null properties.

While we have test coverage for this, and we can merge it, I want to test this @ Hub before doing a release... as there are some props that AGO mandates be set, and we *may* be skirting some of those rules simply by the fact that "null" counts as a value.