### PR TITLE
fix querystring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- invalid querystring on `items-service` `getById` & `getDataById`
 
 ## 0.27.0
 ### Added

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -24,8 +24,8 @@ export default Ember.Service.extend(serviceMixin, {
    * Get the item json
    */
   getById (itemId, portalOpts) {
-    const qs = this.encodeForm({});
-    const urlPath = `/content/items/${itemId}?${qs}&f=json`;
+    const qs = this.encodeForm(this.get('defaultParams'));
+    const urlPath = `/content/items/${itemId}?${qs}`;
     return this.request(urlPath, null, portalOpts);
   },
 
@@ -34,8 +34,8 @@ export default Ember.Service.extend(serviceMixin, {
    * and empty object (`{}`) will be returned by this call
    */
   getDataById (itemId, portalOpts) {
-    const qs = this.encodeForm({});
-    const urlPath = `/content/items/${itemId}/data?${qs}&f=json`;
+    const qs = this.encodeForm(this.get('defaultParams'));
+    const urlPath = `/content/items/${itemId}/data?${qs}`;
     return this.request(urlPath, null, portalOpts);
   },
 


### PR DESCRIPTION
The items-service `getById` and `getDataById` methods created invalid querystings like: `?&f=json` because `encodeForm({})` would return an empty string.