### PR TITLE
Remove unused function that uses a service thats no longer included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - swapped the deprecated `ember-network` for `ember-fetch`
 
+### Removed
+- unused `geometry-service.projectAjax` fn which could not work as the ajax service was not included
+
 ## 0.29.0
 ### Changed
 - upgrade to ember 2.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.30.0
+## 1.0.0
 ### Changed
 - swapped the deprecated `ember-network` for `ember-fetch`
-
 ### Removed
 - unused `geometry-service.projectAjax` fn which could not work as the ajax service was not included
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Ember Services for working with ArcGIS Portal/Online
 
 **Note**  This is still a very nascent project, and things will change.
 
-Be sure to lock to a specific version in your own `package.json`. We expect many breaking changes before a stable `v1.0.0` public API is released.
+We recommend locking to a specific version in your own `package.json` - although we try to avoid breaking changes,
 
 ### ArcGIS Portal Services
 After adding this to your project, you will have a number of services available for injection into your routes/controllers/services.
 
 ### Dependencies
-This project is now using `ember-network/fetch`, which is included in dependencies, to enable fastboot compatibility.
+This project is now using `ember-fetch`, which is included in dependencies.
+
 If you're using `torii` for oauth management, please also `npm install torii-provider-arcgis`. More information [here](https://github.com/dbouwman/torii-provider-arcgis).
 Otherwise, you can use the `portalOpts` parameter described below, but you need a service named `session` in your app or addon. You can generate a dummy service using `ember generate service session`. *TODO: there's probably a better way to do this...*
 
@@ -23,16 +24,14 @@ All the services expose a set of shared helper properties and methods:
 
 | Property | Returns | Description |
 | --- | --- | --- |
-| `portalRestUrl` (deprecated) | `string` | Return the ArcGIS Portal Rest base url |
-| `portalUrl` (deprecated) | `string` | Return the ArcGIS Portal base url (for visiting pages etc) |
 | `geocodeUrl` | `string` | Return the geocode base url |
 
 **NOTE: Most public methods take an optional portalOpts parameter. This takes the form:**
 
 ```
 {
-  portalHostname
-  token
+  portalHostname: 'https://some.portal.com',
+  token: 'BZSOMETOKENQJ'
 }
 ```
 
@@ -40,6 +39,8 @@ All the services expose a set of shared helper properties and methods:
 | --- | --- | --- |
 | `encodeForm` | `string` | This is used internally. Formats an object into a html form. In most cases, not necessary to call this.|
 | `request (url, options, portalOpts)` | `promise` | This is used internally. Promisified xhr that does basic handling of Portal's 400-in-a-200 errors |
+| `getPortalUrl()` | `string` | Get the portal url i.e. `https://org.maps.arcgis.com` |
+| `getPortalRestUrl()` | `string` | Get the portal rest url i.e. `https://org.maps.arcgis.com/sharing/rest` |
 
 ### Items Service
 

--- a/addon/services/geometry-service.js
+++ b/addon/services/geometry-service.js
@@ -1,47 +1,8 @@
 import { computed } from '@ember/object';
-import { Promise as EmberPromise } from 'rsvp';
 import Service from '@ember/service';
 import serviceMixin from '../mixins/service-mixin';
 
 export default Service.extend(serviceMixin, {
-
-  projectAjax (inSR, outSR, geometryType, geometries) {
-    return new EmberPromise((resolve, reject) => {
-      // var serviceUrl = PrincipalService.portal().helperServices.geometry.url
-
-      var serviceUrl = 'https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project';
-
-      var gparam = {
-        geometryType: geometryType,
-        geometries: geometries
-      };
-      var params = {
-        geometries: JSON.stringify(gparam),
-        transformForward: false,
-        transformation: '',
-        inSR: inSR,
-        outSR: outSR,
-        f: 'json'
-      };
-
-      this.get('ajax').request(serviceUrl, {
-        data: params
-      }).then((json /* ,status,headers */) => {
-        // xhr may have returned a 200, but
-        // there could be an error payload...
-        if (json.error) {
-          // reject with the message
-          reject(json.error.message);
-        } else {
-          // all good - resolve with json
-          resolve(json);
-        }
-      }, (json, status, headers) => {
-        console.error(json, status, headers());
-        reject(status);
-      });
-    });
-  },
 
   /**
    * Return the portal's Geometry Service base url if it exists, if not use default

--- a/tests/dummy/app/items/item/edit/controller.js
+++ b/tests/dummy/app/items/item/edit/controller.js
@@ -7,7 +7,6 @@ export default Controller.extend({
   itemsService: service('items-service'),
   sharingService: service('sharing-service'),
 
-
   itemJson: computed('model.item', function () {
     return this.get('model.item');
   }),


### PR DESCRIPTION
Simply removes the `projectAjax` function, which relied on the ember-ajax service which had been removed from the project months ago.