### PR TITLE
add project token logic and portal deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.0
+### Added
+- `geometry-service:project` now takes portalOpts and will send tokens to non `arcgisonline.com` services if provided.
+
 ## 1.1.0
 ### Added
 - `portal-services:addImageResourceFromUrl` method

--- a/addon/services/geometry-service.js
+++ b/addon/services/geometry-service.js
@@ -14,7 +14,7 @@ export default Service.extend(serviceMixin, {
   /**
    * Project some geometries
    */
-  project (inSR, outSR, geometryType, geometries) {
+  project (inSR, outSR, geometryType, geometries, portalOpts) {
     let projectUrl = `${this.get('geometryServerUrl')}/project`;
     var gparam = {
       geometryType: geometryType,
@@ -31,8 +31,10 @@ export default Service.extend(serviceMixin, {
         f: 'json'
       }
     };
-
-    // we dont' want to send a token ever
-    return this.requestUrl(projectUrl, options, {token: ''});
+    // we dont' want to send any tokens ever if we are using the default server...
+    if (projectUrl.indexOf('arcgisonline') > -1 && portalOpts) {
+      portalOpts.token = '';
+    }
+    return this.requestUrl(projectUrl, options, portalOpts);
   }
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "deploy": "ember github-pages:commit --environment=github --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\";",
     "deploy:devext": "ember surge --new-domain='eapsdev.surge.sh' --environment=devext",
     "deploy:qaext": "ember surge --new-domain='eapsqa.surge.sh' --environment=qaext",
-    "deploy:prod": "ember surge --new-domain='eapsprod.surge.sh' --environment=production"
+    "deploy:prod": "ember surge --new-domain='eapsprod.surge.sh' --environment=production",
+    "deploy:portaldev": "ember surge --new-domain='eapsportaldev.surge.sh' --environment=portaldev",
+    "deploy:portalqa": "ember surge --new-domain='eapsportalqa.surge.sh' --environment=portalqa"
   },
   "dependencies": {
     "ember-cli-babel": "^6.7.1",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -94,5 +94,19 @@ module.exports = function (environment) {
     ENV.torii.providers['arcgis-oauth-bearer'].portalUrl = 'https://www.arcgis.com';
   }
 
+  if (environment === 'portalqa') {
+    // PORTALQA App Item: 8c70a15951af474a85fdc90dc0eabe68
+    ENV.rootURL = '/';
+    ENV.torii.providers['arcgis-oauth-bearer'].apiKey = 'sdjz46sRw9Tcjx4n';
+    ENV.torii.providers['arcgis-oauth-bearer'].portalUrl = 'https://portal.hubqa.arcgis.com/portal';
+  }
+
+  if (environment === 'portaldev') {
+    // App Item:
+    ENV.rootURL = '/';
+    ENV.torii.providers['arcgis-oauth-bearer'].apiKey = 'di8zkURhC6XuxY9F';
+    ENV.torii.providers['arcgis-oauth-bearer'].portalUrl = 'https://portal.hubdev.arcgis.com/portal';
+  }
+
   return ENV;
 };


### PR DESCRIPTION
If portalOpts are supplied to `geometry-service:project` and the project call is not going to a `arcgisonline.com` domain, the token will be sent.

Adds deploy goodies for our portal envs
