### PR TITLE
Send credentials with fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0
+### Added
+- `fetch` now defaults to `credentials: 'same-origin'` for all requests, enabling web-tier authentication
+
 ## 1.2.0
 ### Added
 - `geometry-service:project` now takes portalOpts and will send tokens to non `arcgisonline.com` services if provided.

--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -143,6 +143,14 @@ export default Mixin.create({
         opts.body = form;
       }
     }
+    // if we have not overridden credentials, set it to same-origin
+    // which replicates the same behavior as XMLHttpRequest
+    // This is needed to allow credentials to be send in the scenario
+    // where a Portal is configured for web-tier authentication
+    // There is no downside to having this as a default.
+    if (!options.credentials) {
+      options.credentials = 'same-origin';
+    }
 
     // append in the token
     // if portalOpts was provided use it even if it is undefined


### PR DESCRIPTION
`fetch` now defaults to `credentials: 'same-origin'` for all requests, enabling web-tier authentication