### PR TITLE
BUG: Item Service addImageResourceFromUrl was not sending same-origin credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2
+### Changed
+- `utils/fetch-image-as-blob.js` sends same-origin credentials by default
+- `item-service:addImageResourceFromUrl` now uses `fetch-image-as-blob`
+
 ## 1.3.1
 ### Fixed
 - typo in `fetch` when setting credentials

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -1,7 +1,7 @@
 import { copy } from '@ember/object/internals';
 import Service from '@ember/service';
 import serviceMixin from '../mixins/service-mixin';
-import getImageAsBlob from 'ember-arcgis-portal-services/utils/get-image-as-blob';
+import fetchImageAsBlob from 'ember-arcgis-portal-services/utils/fetch-image-as-blob';
 
 export default Service.extend(serviceMixin, {
 
@@ -128,7 +128,7 @@ export default Service.extend(serviceMixin, {
    * Fetch an image from a url, and upload it as a resource to an existing item
    */
   addImageResourceFromUrl (itemId, owner, filename, url) {
-    return getImageAsBlob(url)
+    return fetchImageAsBlob(url)
       .then((blob) => {
         //  upload as a resources
         return this.uploadResource(itemId, owner, blob, filename);

--- a/addon/utils/fetch-image-as-blob.js
+++ b/addon/utils/fetch-image-as-blob.js
@@ -2,8 +2,11 @@
  * Fetch an image from a url, and return it as a blob that can
  * then be uploaded to an item as a resource
  */
-export default function fetchImageAsBlob (url) {
-  return fetch(url)
+export default function fetchImageAsBlob (url, options = {}) {
+  if (!options.credentials) {
+    options.credentials = 'same-origin';
+  }
+  return fetch(url, options)
   .then((response) => {
     return response.blob();
   });


### PR DESCRIPTION
This PR changes the `addImageResourceFromUrl` method to use `fetch` and sends the same-origin credentials. This ensures this method will work with web-tier authentication.