### PR TITLE
bug in logic that prevents tokens for public geometry service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.3
+### Fixed
+- don't send token to geometry service hosted at ArcGISOnline.com
+
 ## 1.3.2
 ### Changed
 - `utils/fetch-image-as-blob.js` sends same-origin credentials by default

--- a/addon/services/geometry-service.js
+++ b/addon/services/geometry-service.js
@@ -32,8 +32,15 @@ export default Service.extend(serviceMixin, {
       }
     };
     // we dont' want to send any tokens ever if we are using the default server...
-    if (projectUrl.indexOf('arcgisonline') > -1 && portalOpts) {
-      portalOpts.token = '';
+    if (projectUrl.indexOf('arcgisonline') > -1) {
+      if (portalOpts) {
+        portalOpts.token = '';
+      } else {
+        // create a portalOpts so the session token does not get sent
+        portalOpts = {
+          token: ''
+        };
+      }
     }
     return this.requestUrl(projectUrl, options, portalOpts);
   }


### PR DESCRIPTION
If portalOpts was not sent, then the logic which removed tokens from the `project` request was not invoked.