### PR TITLE
add @esri/arcgis-rest-common-types as a dev dep to remove npm i warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "broccoli-merge-trees": "^2.0.0"
   },
   "devDependencies": {
+    "@esri/arcgis-rest-common-types": "^1.7.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-cli": "~2.18.0",
     "ember-cli-active-link-wrapper": "0.3.2",


### PR DESCRIPTION
fixes

```bash
➜  ember-arcgis-portal-services git:(master) npm i  
npm WARN @esri/arcgis-rest-auth@1.7.1 requires a peer of @esri/arcgis-rest-common-types@^1.7.1 but none was installed.
npm WARN @esri/arcgis-rest-items@1.7.1 requires a peer of @esri/arcgis-rest-common-types@^1.7.1 but none was installed.
npm WARN @esri/arcgis-rest-sharing@1.7.1 requires a peer of @esri/arcgis-rest-common-types@^1.7.1 but none was installed.
```