### PR TITLE
append https to portalOpts.portalHostname to pass through to rest-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All the services expose a set of shared helper properties and methods:
 
 ```
 {
-  portalHostname: 'https://some.portal.com',
+  portalHostname: 'some.portal.com',
   token: 'BZSOMETOKENQJ'
 }
 ```

--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -180,7 +180,7 @@ export default Mixin.create({
     args.fetch = fetch;
     // if portal options are present, they're preferred
     if (portalOpts && portalOpts.portalHostname) {
-      args.portal = portalOpts.portalHostname + '/sharing/rest';
+      args.portal = `https://${portalOpts.portalHostname}/sharing/rest`;
       if (!args.params) {
         args.params = {};
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,12 @@
       "integrity": "sha512-EscCdfle3v7HLjjTN96p6zwt0uwOymUMM9T8+3UG7WhCJUGWkXVpHgHY8/OuL/ed5SKRfF9nAAfh3CoMBbcuTg==",
       "requires": {
         "tslib": "^1.7.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "bundled": true
+        }
       }
     },
     "@esri/arcgis-rest-request": {

--- a/tests/unit/mixins/service-mixin-test.js
+++ b/tests/unit/mixins/service-mixin-test.js
@@ -68,7 +68,7 @@ test('addOptions, with portal options', function (assert) {
     authMgr: {}
   });
 
-  const enriched = subject.addOptions({foo: 'bar'}, {token: 'token', portalHostname: 'https://super.custom'});
+  const enriched = subject.addOptions({foo: 'bar'}, {token: 'token', portalHostname: 'super.custom'});
 
   assert.equal(enriched.foo, 'bar', 'original props should still be present');
   assert.equal(enriched.fetch, fetch, 'fetch should be tacked on');


### PR DESCRIPTION
tested in production and realized the doc here was wrong...