### PR TITLE
use pre-rest-js format for error codes and messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- use pre-rest-js format for error codes and messages
+
 ## [1.6.0]
 ### Added
 - `hosted-service` `ensureUniqueServiceName` method

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import serviceMixin from '../mixins/service-mixin';
 import fetchImageAsBlob from 'ember-arcgis-portal-services/utils/fetch-image-as-blob';
+import { handleError } from 'ember-arcgis-portal-services/utils/errors';
 import {
   searchItems,
   getItem,
@@ -26,7 +27,8 @@ export default Service.extend(serviceMixin, {
    */
   search (form, portalOpts) {
     const args = this.addOptions({ searchForm: form }, portalOpts);
-    return searchItems(args);
+    return searchItems(args)
+    .catch(handleError);
   },
 
   /**
@@ -34,7 +36,8 @@ export default Service.extend(serviceMixin, {
    */
   getById (itemId, portalOpts) {
     const args = this.addOptions({}, portalOpts);
-    return getItem(itemId, args);
+    return getItem(itemId, args)
+    .catch(handleError);
   },
 
   /**
@@ -43,7 +46,8 @@ export default Service.extend(serviceMixin, {
    */
   getDataById (itemId, portalOpts) {
     const args = this.addOptions({}, portalOpts);
-    return getItemData(itemId, args);
+    return getItemData(itemId, args)
+    .catch(handleError);
   },
 
   /**
@@ -52,7 +56,8 @@ export default Service.extend(serviceMixin, {
    */
   update (item, portalOpts) {
     const args = this.addOptions({ item, owner: item.owner }, portalOpts);
-    return updateItem(args);
+    return updateItem(args)
+    .catch(handleError);
   },
 
   /**
@@ -66,7 +71,8 @@ export default Service.extend(serviceMixin, {
       folder: folderId
     }, portalOpts);
 
-    return createItemInFolder(args);
+    return createItemInFolder(args)
+    .catch(handleError);
   },
 
   /**
@@ -87,7 +93,8 @@ export default Service.extend(serviceMixin, {
       owner
     }, portalOpts);
 
-    return removeItem(args);
+    return removeItem(args)
+    .catch(handleError);
   },
 
   protect (itemId, owner, portalOpts) {
@@ -96,7 +103,8 @@ export default Service.extend(serviceMixin, {
       owner
     }, portalOpts);
 
-    return protectItem(args);
+    return protectItem(args)
+    .catch(handleError);
   },
 
   unprotect (itemId, owner, portalOpts) {
@@ -105,7 +113,8 @@ export default Service.extend(serviceMixin, {
       owner
     }, portalOpts);
 
-    return unprotectItem(args);
+    return unprotectItem(args)
+    .catch(handleError);
   },
 
   /**

--- a/addon/services/sharing-service.js
+++ b/addon/services/sharing-service.js
@@ -4,6 +4,7 @@ import { debug } from '@ember/debug';
 import { reject, resolve } from 'rsvp';
 import Service, { inject as service } from '@ember/service';
 import serviceMixin from '../mixins/service-mixin';
+import { handleError } from 'ember-arcgis-portal-services/utils/errors';
 import { setItemAccess } from '@esri/arcgis-rest-sharing';
 
 export default Service.extend(serviceMixin, {
@@ -26,7 +27,8 @@ export default Service.extend(serviceMixin, {
       access,
     }, portalOpts);
 
-    return setItemAccess(args);
+    return setItemAccess(args)
+    .catch(handleError);
   },
   /**
    * Share an item with a group, optionally with item control

--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -1,0 +1,17 @@
+// inspect errors from @ersri/arcgis-rest-request and
+// throw a new error in the format used by serviceMixin.request()
+export function handleError (err) {
+  // get the orignal error info returned in the response
+  const response = err.response;
+  const errorJson = response && response.error;
+  if (errorJson && (err.code !== errorJson.code || err.message !== errorJson.message)) {
+    // error code or message is different than the format we've sent up to v1.5.0
+    // throw a new error with the expected format
+    const error = new Error(errorJson.message);
+    error.code = errorJson.code || 404;
+    error.response = response;
+    throw error;
+  }
+  // just re-throw
+  throw err;
+}

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -1,0 +1,1 @@
+export { handleError } from 'ember-arcgis-portal-services/utils/format-rest-js-error';

--- a/tests/unit/utils/errors.js
+++ b/tests/unit/utils/errors.js
@@ -1,0 +1,40 @@
+import { handleError } from 'dummy/utils/errors';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | format rest js error');
+
+test('it throws a new error when diff code/message', function (assert) {
+  // TODO: create an actual error instead of just using an object
+  /* eslint-disable quotes */
+  const restJsError = {
+    "name": "ArcGISRequestError",
+    "message": "CONT_0001: Item does not exist or is inaccessible.",
+    "originalMessage": "Item does not exist or is inaccessible.",
+    "code": "CONT_0001",
+    "response": {
+      "error": {
+        "code": 400,
+        "messageCode": "CONT_0001",
+        "message": "Item does not exist or is inaccessible.",
+        "details": []
+      }
+    },
+    "url": "https://dc.mapsdevext.arcgis.com/sharing/rest/content/items/bbc0882d4713479c87bedcd6b3c41d1ah?f=json&token=w6ddxdYAY4WvtmrqZXyj3uMxQx7Pe8gzzRdZBH1DuniCIxEMt5wonLZMb-lGn7d6TpohGt7QU_lw4ume0RYMapC1qPGvWuV4tvRrh3pTSckJJCboqIkUzk70PGrVfNlWUemfj99mpVR6Xhq1XBqNzR4CBGPVjliKlqQMSi3hIW5XjCvAEn9u-GptFu26NX9O9XYYUh4S-OmT9BTaE_JA3Q..",
+    "options": {
+      "httpMethod": "GET",
+      "portal": "https://dc.mapsdevext.arcgis.com/sharing/rest",
+      "params": {
+        "token": "notarealtoken"
+      }
+    }
+  };
+  /* eslint-enable quotes */
+
+  assert.throws(handleError(restJsError), err => {
+    return err.message === 'Item does not exist or is inaccessible.' && err.code === 400;
+  }, 'throws a new error with the original message');
+});
+
+// TODO: confirm that 404 code is used if no original code was returned
+
+// TODO: test that original error is thrown if code/message are the same


### PR DESCRIPTION
should resolve https://github.com/ArcGIS/opendata-ui/issues/3282 the related bug we saw on QA this morning before when attempting to access private Hub sites before https://github.com/ArcGIS/opendata-ui/pull/3285
