### PR TITLE
handle unauthenticated requests in addOptions and fix tests

### DIFF
--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -194,12 +194,12 @@ export default Mixin.create({
       }
     } else {
       // get portal and authtentication from the session
+      let correctPortalRestUrl = this.getPortalRestUrl();
       let authMgr = this.get('session.authMgr');
       if (authMgr) {
         // first verify that the cached authentication has the right portal
         // ---------------------------------------------------
         // TODO: just a test - this should be done in Torii
-        let correctPortalRestUrl = this.getPortalRestUrl();
         if (authMgr.portal !== correctPortalRestUrl) {
           debug(`AuthMgr.portal: ${authMgr.portal}`);
           debug(`session.portalHostname: ${this.get('session.portalHostname')}`);
@@ -207,6 +207,9 @@ export default Mixin.create({
         }
         // ---------------------------------------------------
         args.authentication = authMgr;
+      } else {
+        // user is unauthenticated, but we may still have a portalHostname
+        args.portal = correctPortalRestUrl;
       }
     }
 

--- a/tests/unit/mixins/service-mixin-test.js
+++ b/tests/unit/mixins/service-mixin-test.js
@@ -50,7 +50,8 @@ test('addOptions, unauthenticated', function (assert) {
   let subject = ServiceMixinObject.create();
 
   subject.set('session', {
-    // NOTE: I'm guessing {} ~= an unauthenticated session
+    // NOTE: sometimes in hub the `session.portalHostname` for unauthenticated requests
+    portalHostname: 'https://session.host.com',
   });
 
   const enriched = subject.addOptions({foo: 'bar'});
@@ -59,7 +60,7 @@ test('addOptions, unauthenticated', function (assert) {
   assert.equal(enriched.fetch, fetch, 'fetch should be tacked on');
   assert.notOk(enriched.params, 'token param should NOT be set');
   assert.notOk(enriched.authentication, 'auth from torii should NOT be tacked on');
-  assert.notOk(enriched.portal, 'portal should NOT be set');
+  assert.equal(enriched.portal, 'https://session.host.com/sharing/rest', 'portal should come from session');
 });
 
 test('addOptions, authenticated sesssion', function (assert) {


### PR DESCRIPTION
Implements the suggestions I made in https://github.com/Esri/ember-arcgis-portal-services/pull/132#pullrequestreview-149934109 and fixes tests. Namely:
- re-allow unauthenticated requests via portalOpts: if no token was passed, set `portal` instead of `authentication`
- use `this.getPortalRestUrl(portalOptions)` to ensure consistency w/ <= v1.5.0
- fix broken tests
- misc clean comments and clean up