### PR TITLE
Chore/configure eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'semistandard',
-    // 'plugin:ember/recommended'
+    'plugin:ember/recommended'
   ],
   env: {
     browser: true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: 'module'
   },
+  plugins: [
+    'ember'
+  ],
   extends: [
     'eslint:recommended',
     'semistandard',
@@ -16,10 +19,8 @@ module.exports = {
     "comma-dangle": [2, "only-multiline"],
     "no-console": 0,
     "indent": [2, 2, { "SwitchCase": 1, "MemberExpression": "off" }],
+    "ember/no-jquery": 2,
   },
-  // plugins: [
-  //   'ember'
-  // ],
   overrides: [
     // node files
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- configure eslint to use default ember rules
+- configure eslint to use default ember rules & avoid jQuery
 
 ## [1.7.1]
 - bump to torii-provider-arcgis v2.0.0 so session.authMgr has correct portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### changed
+- configure eslint to use default ember rules & avoid jQuery
+
+## [1.8.0]
 ### added
 - `user-service` `getNotifications` and `removeNotification` methods
 - `portal-service` `sendEmailNotification`, `sendBuiltinNotification`, & `sendPushNotification` methods
@@ -12,7 +16,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - upgraded arcgis-rest-js to 1.9.0
 - deprecated `portal-service` `sendMessage` method
 - deprecated `groups-service` `sendGroupMessage` method
-- configure eslint to use default ember rules & avoid jQuery
 
 ## [1.7.1]
 - bump to torii-provider-arcgis v2.0.0 so session.authMgr has correct portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- configure eslint to use default ember rules
 
 ## [1.7.1]
 - bump to torii-provider-arcgis v2.0.0 so session.authMgr has correct portal

--- a/addon/services/geocode-service.js
+++ b/addon/services/geocode-service.js
@@ -1,3 +1,4 @@
+// TODO: remove jQuery - this should have been caught by eslint
 import $ from 'jquery';
 import { computed } from '@ember/object';
 import Service from '@ember/service';
@@ -18,6 +19,7 @@ export default Service.extend(serviceMixin, {
       maxLocations: 1,
       bbox: null
     };
+    // TODO: find a non-jQuery way to deep merge options into defaults
     let ops = $.extend({}, defaults, options);
     let url = `${geocodeUrl}findAddressCandidates?f=json&singleLine=${inputString}&maxLocations=${ops.maxLocations}&outSR=${ops.outSR}`;
 

--- a/tests/unit/services/sharing-service-test.js
+++ b/tests/unit/services/sharing-service-test.js
@@ -22,9 +22,11 @@ test('it exists', function (assert) {
 
 test('owner share to group', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'fakeuser'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return false;
     }
@@ -66,9 +68,11 @@ test('owner share to group', function (assert) {
 
 test('owner re-share to group', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'fakeuser'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return false;
     }
@@ -96,9 +100,11 @@ test('owner re-share to group', function (assert) {
 
 test('admin re-share to group', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'fakeadmin'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return true;
     }
@@ -126,9 +132,11 @@ test('admin re-share to group', function (assert) {
 
 test('owner share to group with itemControl', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'fakeuser'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return false;
     }
@@ -168,9 +176,11 @@ test('owner share to group with itemControl', function (assert) {
 
 test('owner share to group message response', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'fakeuser'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return false;
     }
@@ -206,9 +216,11 @@ test('owner share to group message response', function (assert) {
 
 test('non-owner can not share item to group', function (assert) {
   let session = Service.extend({
+    /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
     currentUser: {
       username: 'otherfakeuser'
     },
+    /* eslint-enable ember/avoid-leaking-state-in-ember-objects */
     isAdmin: function () {
       return false;
     }


### PR DESCRIPTION
Configure eslint to use default ember rules & avoid jQuery.

TODO:

I'm not sure why, but eslint is not picking up the use of jQuery in [addon/services/geocode-service.js](https://github.com/Esri/ember-arcgis-portal-services/compare/chore/configure-eslint?expand=1#diff-5c43a7a0cb851787474c7cc039be1abf)

Maybe it doesn't run on services?
