### PR TITLE
User security settings methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased
+## [Unreleased]
+### added
+- `user-service` `getSecuritySettings` and `generateToken` methods
+- `portal-service` `getSecurityPolicy` method
 
 ## [1.12.0]
 - adds ability to POST multipart/form-data requests from users service

--- a/addon/services/portal-service.js
+++ b/addon/services/portal-service.js
@@ -16,6 +16,11 @@ export default Service.extend(serviceMixin, {
     return this.request(urlPath, null, portalOpts);
   },
 
+  getSecurityPolicy (portalOpts) {
+    const urlPath = `/portals/self/securityPolicy?f=json`;
+    return this.request(urlPath, null, portalOpts);
+  },
+
   /**
    * Update the portal
    */

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -94,6 +94,12 @@ export default Service.extend(serviceMixin, {
     return declineInvitation(args);
   },
 
+  getSecuritySettings (portalOpts) {
+    let {username} = this.get('session.currentUser');
+    const urlPath = `/community/users/${username}/forgotPassword?f=json`;
+    return this.request(urlPath, null, portalOpts);
+  },
+
   /**
    * Extra logic to transform the item prior to POSTing it
    */

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -10,6 +10,7 @@ import {
   acceptInvitation,
   declineInvitation
 } from '@esri/arcgis-rest-users';
+import { generateToken } from '@esri/arcgis-rest-auth';
 
 export default Service.extend(serviceMixin, {
 
@@ -101,10 +102,10 @@ export default Service.extend(serviceMixin, {
     return this.request(urlPath, null, portalOpts);
   },
 
-  // TODO: use arcgis-rest-js method https://esri.github.io/arcgis-rest-js/api/auth/generateToken
-  generateToken (user, portalOpts, formData) {
-    const urlPath = `/generateToken?f=json`;
-    return this._post(urlPath, formData || user, portalOpts);
+  generateToken (params, portalOpts) {
+    const url = `${this.getPortalRestUrl(portalOpts)}/generateToken?f=json`;
+    const args = this.addOptions({params}, portalOpts);
+    return generateToken(url, args);
   },
 
   /**

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -100,6 +100,11 @@ export default Service.extend(serviceMixin, {
     return this.request(urlPath, null, portalOpts);
   },
 
+  generateToken (user, portalOpts, formData) {
+    const urlPath = `/generateToken?f=json`;
+    return this._post(urlPath, formData || user, portalOpts);
+  },
+
   /**
    * Extra logic to transform the item prior to POSTing it
    */

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -94,12 +94,14 @@ export default Service.extend(serviceMixin, {
     return declineInvitation(args);
   },
 
+  // TODO: migrate to arcgis-rest-js
   getSecuritySettings (portalOpts) {
     let {username} = this.get('session.currentUser');
     const urlPath = `/community/users/${username}/forgotPassword?f=json`;
     return this.request(urlPath, null, portalOpts);
   },
 
+  // TODO: use arcgis-rest-js method https://esri.github.io/arcgis-rest-js/api/auth/generateToken
   generateToken (user, portalOpts, formData) {
     const urlPath = `/generateToken?f=json`;
     return this._post(urlPath, formData || user, portalOpts);


### PR DESCRIPTION
[story](https://esriarlington.tpondemand.com/entity/87496-user-can-change-their-password-security)

Adds methods so that users can change their passwords and security questions via Hub.

- `userService.getSecuritySettings` returns a user's security question index
- `userService.generateToken` returns a token, which is used to validation username/password combination against a portal instance
- `portalService.getSecurityPolicy` returns requirements for passwords (min length, number uppercase, etc) of a portal instance