### PR TITLE
Platform SSO and Friends

### DIFF
--- a/addon/mixins/service-mixin.js
+++ b/addon/mixins/service-mixin.js
@@ -169,6 +169,7 @@ export default Mixin.create({
         url = url + '?token=' + token;
       }
     }
+
     // Ember.debug('Portal Services making request to: ' + url);
     return fetch(url, opts)
     // we need the => here, just .then(this.checkStatusAndParseJson) causes problems with rejection

--- a/addon/services/portal-service.js
+++ b/addon/services/portal-service.js
@@ -256,4 +256,9 @@ export default Service.extend(serviceMixin, {
     return this._post(urlPath, opts, portalOpts);
   },
 
+  getUserDefaultSettings (portalOpts) {
+    const urlPath = `/portals/self/userDefaultSettings?f=json`;
+    return this.request(urlPath, {}, portalOpts);
+  }
+
 });

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -1,7 +1,8 @@
-import { copy } from '@ember/object/internals';
+
 import { deprecate } from '@ember/application/deprecations';
 import Service, { inject as service } from '@ember/service';
 import serviceMixin from '../mixins/service-mixin';
+import { cloneObject } from 'ember-arcgis-portal-services/utils/clone-object';
 import {
   getUserNotifications,
   removeNotification,
@@ -112,13 +113,13 @@ export default Service.extend(serviceMixin, {
    * Extra logic to transform the item prior to POSTing it
    */
   _serializeUser (user) {
-    let clone = copy(user, true);
+    let clone = cloneObject(user);
 
     // groups are ignored
     delete clone.groups;
 
     // Array items need to become comma delim strings
-    if (user.tags && user.tags.join) {
+    if (Array.isArray(user.tags)) {
       clone.tags = user.tags.join(', ');
       if (clone.tags === '') {
         // NOTE: you can't currently reset the tags to an empty array
@@ -126,6 +127,10 @@ export default Service.extend(serviceMixin, {
         // http://resources.arcgis.com/en/help/arcgis-rest-api/#/Update_User/02r3000000m0000000/
         clone.tags = 'user';
       }
+    }
+
+    if (Array.isArray(user.typeKeywords)) {
+      clone.typeKeywords = user.typeKeywords.join(', ');
     }
 
     return clone;

--- a/addon/services/user-service.js
+++ b/addon/services/user-service.js
@@ -129,10 +129,6 @@ export default Service.extend(serviceMixin, {
       }
     }
 
-    if (Array.isArray(user.typeKeywords)) {
-      clone.typeKeywords = user.typeKeywords.join(', ');
-    }
-
     return clone;
   },
 

--- a/addon/utils/clone-object.js
+++ b/addon/utils/clone-object.js
@@ -1,0 +1,24 @@
+
+/**
+ * @esri/hub-common cloneObject function
+ * Copied into this addon instead of loading the package
+ * to avoid bloat. Someday, when Ember has treeshaking...
+ */
+export function cloneObject (obj) {
+  let clone = {};
+  // first check array
+  if (Array.isArray(obj)) {
+    clone = obj.map(cloneObject);
+  } else if (typeof obj === 'object') {
+    for (const i in obj) {
+      if (obj[i] != null && typeof obj[i] === 'object') {
+        clone[i] = cloneObject(obj[i]);
+      } else {
+        clone[i] = obj[i];
+      }
+    }
+  } else {
+    clone = obj;
+  }
+  return clone;
+}

--- a/app/utils/clone-object.js
+++ b/app/utils/clone-object.js
@@ -1,0 +1,1 @@
+export { cloneObject } from 'ember-arcgis-portal-services/utils/clone-object';

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -17,6 +17,34 @@ export default Controller.extend({
     return this.get('model.portal.portalProperties');
   }),
 
+  userDefaultsJson: computed('model.userDefaultSettings', function () {
+    return this.get('model.userDefaultSettings');
+  }),
+
+  jsonPortal: computed('model.portal', function () {
+    return JSON.stringify(this.get('model.portal'), null, 4);
+  }),
+
+  hasPlatformSSO: computed('model.portal.platformSSO', function () {
+    return this.get('model.portal.platformSSO');
+  }),
+
+  userDefaultsExample: computed('model.portal', function () {
+    return JSON.stringify({
+      role: 'org_publisher',
+      userLicenseType: 'creatorUT',
+      groups: ['group-id-you-want-users-joined-to']
+    }, null, 4);
+  }),
+
+  setPlatformSSO (val) {
+    // set it on the model...
+    this.set('model.portal.platformSSO', val);
+    let portal = this.get('model.portal');
+
+    return this.get('portalService').update(portal);
+  },
+
   actions: {
     removeResource (resourceName) {
       return this.get('portalService').removeResource(resourceName);
@@ -44,6 +72,19 @@ export default Controller.extend({
           this.set('dirty', false);
         }
       });
+    },
+
+    enablePlatformSSO () {
+      this.setPlatformSSO(true);
+    },
+
+    disablePlatformSSO () {
+      this.setPlatformSSO(false);
+    },
+
+    saveUserDefaults () {
+      const userDefaults = this.get('userDefaultsJson');
+      return this.get('portalService').setUserDefaultSettings(userDefaults);
     }
   }
 });

--- a/tests/dummy/app/portal/route.js
+++ b/tests/dummy/app/portal/route.js
@@ -9,7 +9,8 @@ export default Route.extend({
   model () {
     return hash({
       portal: this.get('session.portal'),
-      resources: this.get('portalService').getResources()
+      resources: this.get('portalService').getResources(),
+      userDefaultSettings: this.get('portalService').getUserDefaultSettings()
     });
   }
 });

--- a/tests/dummy/app/portal/template.hbs
+++ b/tests/dummy/app/portal/template.hbs
@@ -8,6 +8,7 @@
       <strong>Please...</strong> do not make ANY changes here if you are not 100% sure about what you are doing.
     </div>
   </div>
+
   <div class="col-sm-6">
     <h3>Portal Settings </h3>
     <ul>
@@ -15,14 +16,39 @@
       <li>Id: {{model.portal.id}}</li>
       <li>Access: {{model.portal.access}}</li>
       <li>All SSL: {{model.portal.allSSL}}</li>
+      <li>Platform SSO: {{hasPlatformSSO}}</li>
       <li>Created: {{createDate}}</li>
       <li>Modified: {{modifyDate}}</li>
     </ul>
   </div>
   <div class="col-sm-6">
-    <h3>Portal Properties Json <button class="btn btn-primary pull-right" {{action 'saveChanges'}}>Save</button></h3>
-    {{json-editor json=propertiesJson mode="code" onChange=(action (mut propertiesJson))}}
+    <h3>Toggle Platform SSO</h3>
+    {{#if hasPlatformSSO}}
+      <button class="btn btn-danger" {{action "disablePlatformSSO"}}>Disable Platform SSO</button>
+    {{else}}
+      <button class="btn btn-success" {{action "enablePlatformSSO"}}>Enable Platform SSO</button>
+    {{/if}}
   </div>
+</div>
+<div class="row">
+  <div class="col-sm-6">
+    <h3>User Default Settings <button class="btn btn-primary pull-right" {{action 'saveUserDefaults'}}>Save User Defaults</button></h3>
+    {{json-editor json=userDefaultsJson mode="code" onChange=(action (mut userDefaultsJson))}}
+    <h5>Example</h5>
+    <p>All properties are required!</p>
+    <pre>
+      <code>
+{{userDefaultsExample}}
+      </code>
+    </pre>
+  </div>
+  <div class="col-sm-6">
+    <h3>Portal Properties Json <button class="btn btn-primary pull-right" {{action 'saveChanges'}}>Save Properties</button></h3>
+    {{json-editor json=propertiesJson mode="code" onChange=(action (mut propertiesJson))}}
+
+  </div>
+</div>
+<div class="row">
   <div class="col-sm-12">
     {{portal-resources
       onFetchResources=(action 'fetchResources')
@@ -30,5 +56,13 @@
       onUploadFile=(action 'uploadFile')
       onJsonUpload=(action 'sendJson')
       }}
+  </div>
+  <div class="col-sm-12">
+    <h3>Portal Json</h3>
+    <pre>
+      <code>
+{{jsonPortal}}
+      </code>
+    </pre>
   </div>
 </div>

--- a/tests/unit/services/user-service-test.js
+++ b/tests/unit/services/user-service-test.js
@@ -12,7 +12,6 @@ moduleFor('service:user-service', 'Unit | Service | user service', {
   }
 });
 
-// Replace this with your real tests.
 test('it serializes tags', function (assert) {
   const service = this.subject();
   const user = {
@@ -22,4 +21,13 @@ test('it serializes tags', function (assert) {
   assert.equal(service._serializeUser(user).tags, user.tags.join(', '), 'should return comma delimited list');
   user.tags = [];
   assert.equal(service._serializeUser(user).tags, 'user', 'should return default tag for empty array');
+});
+
+test('it serializes typeKeywords', function (assert) {
+  const service = this.subject();
+  const user = {
+    username: 'tomwayson',
+    typeKeywords: ['test', 'test1']
+  };
+  assert.equal(service._serializeUser(user).typeKeywords, user.typeKeywords.join(', '), 'should return comma delimited list');
 });

--- a/tests/unit/services/user-service-test.js
+++ b/tests/unit/services/user-service-test.js
@@ -22,12 +22,3 @@ test('it serializes tags', function (assert) {
   user.tags = [];
   assert.equal(service._serializeUser(user).tags, 'user', 'should return default tag for empty array');
 });
-
-test('it serializes typeKeywords', function (assert) {
-  const service = this.subject();
-  const user = {
-    username: 'tomwayson',
-    typeKeywords: ['test', 'test1']
-  };
-  assert.equal(service._serializeUser(user).typeKeywords, user.typeKeywords.join(', '), 'should return comma delimited list');
-});

--- a/tests/unit/utils/clone-object-test.js
+++ b/tests/unit/utils/clone-object-test.js
@@ -1,0 +1,38 @@
+import { cloneObject } from 'ember-arcgis-portal-services/utils/clone-object';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | cloneObject', function (hooks) {
+  // Replace this with your real tests.
+  test('it works', function (assert) {
+    const obj = {
+      color: 'red',
+      length: 12
+    };
+    const c = cloneObject(obj);
+    assert.notEqual(c, obj);
+
+    ['color', 'length'].map(prop => {
+      assert.equal(c[prop], obj[prop]);
+    });
+  });
+  test('can clone a deep object', function (assert) {
+    const obj = {
+      color: 'red',
+      length: 12,
+      field: {
+        name: 'origin',
+        type: 'string'
+      }
+    };
+    const c = cloneObject(obj);
+    assert.notEqual(c, obj);
+    assert.notEqual(c.field, obj.field);
+
+    ['color', 'length'].map(prop => {
+      assert.equal(c[prop], obj[prop]);
+    });
+    ['name', 'type'].map(prop => {
+      assert.equal(c[prop], obj[prop]);
+    });
+  });
+});


### PR DESCRIPTION
Number of small updates:
- minor changes to user-service
   - add `getUserDefaultSettings`
   - use `Array.isArray` in `_serializeUser`
   - add serialization of `typeKeywords` property, which is rumored to be a thing, although I can't find any docs or evidence of it being a thing, but I have a story that's supposed to make use of it, so I added it
- add SSO & User Default Settings to the /portal editor UI
- remove use of internal copy, add cloneObject, with tests