### PR TITLE
fix bug in groups-service doesGroupExist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- bug in `groups-service` where `doesGroupExist` would incorrectly report that a group name exists.
+
 ## [2.1.0]
 ### Added
 - 'groups-service' 'addAdmins' method.

--- a/addon/services/groups-service.js
+++ b/addon/services/groups-service.js
@@ -339,7 +339,7 @@ export default Service.extend(serviceMixin, {
     }
 
     return orgIdPromise
-    .then(orgId => ({ q: `(${title} accountid:${orgId})` }))
+    .then(orgId => ({ q: `title:"(${title}" accountid:${orgId})` }))
     .then(query => {
       return this.search(query, portalOpts);
     })


### PR DESCRIPTION
Currently if the following groups exist:

1. Riddler Followers Initiative Initiative Collaboration Group
1. Riddler Followers Initiative Initiative Open Data Group

`groupsService.doesGroupExist('Riddler Followers Initiative Followers')` will incorrectly return true.

This fixes that error by constraining the query more tightly.