### PR TITLE
add signinSettings to dummy app

### DIFF
--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -21,12 +21,20 @@ export default Controller.extend({
     return this.get('model.userDefaultSettings');
   }),
 
+  signinSettingsJson: computed('model.signinSettings', function () {
+    return this.get('model.signinSettings');
+  }),
+
   jsonPortal: computed('model.portal', function () {
     return JSON.stringify(this.get('model.portal'), null, 4);
   }),
 
   hasPlatformSSO: computed('model.portal.platformSSO', function () {
     return this.get('model.portal.platformSSO');
+  }),
+
+  enableArcGISAutoSignups: computed('model.signinSettings.enableArcGISAutoSignups', function () {
+    return this.get('model.signinSettings.enableArcGISAutoSignups');
   }),
 
   userDefaultsExample: computed('model.portal', function () {
@@ -85,6 +93,19 @@ export default Controller.extend({
     saveUserDefaults () {
       const userDefaults = this.get('userDefaultsJson');
       return this.get('portalService').setUserDefaultSettings(userDefaults);
+    },
+
+    saveSigninSettings () {
+      const signinSettings = this.get('signinSettingsJson');
+      return this.get('portalService').setSigninSettings(signinSettings);
+    },
+
+    disableArcGISAutoSignups () {
+      this.setSigninSettings({enableArcGISAutoSignups:false});
+    },
+
+    enableArcGISAutoSignups () {
+      this.setSigninSettings({enableArcGISAutoSignups:true});
     }
   }
 });

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -33,7 +33,7 @@ export default Controller.extend({
     return this.get('model.portal.platformSSO');
   }),
 
-    userDefaultsExample: computed('model.signinSettings', function () {
+    userDefaultsExample: computed('model.portal', function () {
     return JSON.stringify({
       role: 'org_publisher',
       userLicenseType: 'creatorUT',
@@ -41,7 +41,7 @@ export default Controller.extend({
     }, null, 4);
   }),
 
-  signinSettingsExample: computed('model.portal', function () {
+  signinSettingsExample: computed('model.signinSettings', function () {
     return JSON.stringify({
         "termsAndConditions": "Must love klaus",
         "hideCrossOrgSigninLink": true,

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -35,6 +35,14 @@ export default Controller.extend({
 
   userDefaultsExample: computed('model.portal', function () {
     return JSON.stringify({
+        "termsAndConditions": "Must love klaus",
+        "hideCrossOrgSigninLink": true,
+        "enableArcGISAutoSignups": false
+    }, null, 4);
+  }),
+
+  signinSettingsExample: computed('model.signinSettings', function () {
+    return JSON.stringify({
       role: 'org_publisher',
       userLicenseType: 'creatorUT',
       groups: ['group-id-you-want-users-joined-to']

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -43,9 +43,9 @@ export default Controller.extend({
 
   signinSettingsExample: computed('model.signinSettings', function () {
     return JSON.stringify({
-      'termsAndConditions': 'Must love klaus',
-      'hideCrossOrgSigninLink': true,
-      'enableArcGISAutoSignups': false
+      termsAndConditions: 'Must love klaus',
+      hideCrossOrgSigninLink: true,
+      enableArcGISAutoSignups: false
     }, null, 4);
   }),
 

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -33,19 +33,19 @@ export default Controller.extend({
     return this.get('model.portal.platformSSO');
   }),
 
-  userDefaultsExample: computed('model.portal', function () {
-    return JSON.stringify({
-        "termsAndConditions": "Must love klaus",
-        "hideCrossOrgSigninLink": true,
-        "enableArcGISAutoSignups": false
-    }, null, 4);
-  }),
-
-  signinSettingsExample: computed('model.signinSettings', function () {
+    userDefaultsExample: computed('model.signinSettings', function () {
     return JSON.stringify({
       role: 'org_publisher',
       userLicenseType: 'creatorUT',
       groups: ['group-id-you-want-users-joined-to']
+    }, null, 4);
+  }),
+
+  signinSettingsExample: computed('model.portal', function () {
+    return JSON.stringify({
+        "termsAndConditions": "Must love klaus",
+        "hideCrossOrgSigninLink": true,
+        "enableArcGISAutoSignups": false
     }, null, 4);
   }),
 

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -33,7 +33,7 @@ export default Controller.extend({
     return this.get('model.portal.platformSSO');
   }),
 
-    userDefaultsExample: computed('model.portal', function () {
+  userDefaultsExample: computed('model.portal', function () {
     return JSON.stringify({
       role: 'org_publisher',
       userLicenseType: 'creatorUT',

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -43,9 +43,9 @@ export default Controller.extend({
 
   signinSettingsExample: computed('model.signinSettings', function () {
     return JSON.stringify({
-        "termsAndConditions": "Must love klaus",
-        "hideCrossOrgSigninLink": true,
-        "enableArcGISAutoSignups": false
+      'termsAndConditions': 'Must love klaus',
+      'hideCrossOrgSigninLink': true,
+      'enableArcGISAutoSignups': false
     }, null, 4);
   }),
 

--- a/tests/dummy/app/portal/controller.js
+++ b/tests/dummy/app/portal/controller.js
@@ -33,10 +33,6 @@ export default Controller.extend({
     return this.get('model.portal.platformSSO');
   }),
 
-  enableArcGISAutoSignups: computed('model.signinSettings.enableArcGISAutoSignups', function () {
-    return this.get('model.signinSettings.enableArcGISAutoSignups');
-  }),
-
   userDefaultsExample: computed('model.portal', function () {
     return JSON.stringify({
       role: 'org_publisher',
@@ -98,14 +94,6 @@ export default Controller.extend({
     saveSigninSettings () {
       const signinSettings = this.get('signinSettingsJson');
       return this.get('portalService').setSigninSettings(signinSettings);
-    },
-
-    disableArcGISAutoSignups () {
-      this.setSigninSettings({enableArcGISAutoSignups:false});
-    },
-
-    enableArcGISAutoSignups () {
-      this.setSigninSettings({enableArcGISAutoSignups:true});
     }
   }
 });

--- a/tests/dummy/app/portal/route.js
+++ b/tests/dummy/app/portal/route.js
@@ -10,7 +10,8 @@ export default Route.extend({
     return hash({
       portal: this.get('session.portal'),
       resources: this.get('portalService').getResources(),
-      userDefaultSettings: this.get('portalService').getUserDefaultSettings()
+      userDefaultSettings: this.get('portalService').getUserDefaultSettings(),
+      signinSettings: this.get('portalService').getSigninSettings()
     });
   }
 });

--- a/tests/dummy/app/portal/template.hbs
+++ b/tests/dummy/app/portal/template.hbs
@@ -31,8 +31,12 @@
   </div>
 </div>
 <div class="row">
-  <div class="col-sm-6">
-    <h3>User Default Settings <button class="btn btn-primary pull-right" {{action 'saveUserDefaults'}}>Save User Defaults</button></h3>
+  <div class="col-sm-4">
+    <h3>Portal Properties<button class="btn btn-primary pull-right" {{action 'saveChanges'}}>Save Properties</button></h3>
+    {{json-editor json=propertiesJson mode="code" onChange=(action (mut propertiesJson))}}
+  </div>
+  <div class="col-sm-4">
+    <h3>Usr Default<button class="btn btn-primary pull-right" {{action 'saveUserDefaults'}}>Save User Defaults</button></h3>
     {{json-editor json=userDefaultsJson mode="code" onChange=(action (mut userDefaultsJson))}}
     <h5>Example</h5>
     <p>All properties are required!</p>
@@ -42,10 +46,11 @@
       </code>
     </pre>
   </div>
-  <div class="col-sm-6">
-    <h3>Portal Properties Json <button class="btn btn-primary pull-right" {{action 'saveChanges'}}>Save Properties</button></h3>
-    {{json-editor json=propertiesJson mode="code" onChange=(action (mut propertiesJson))}}
-
+  <div class="col-sm-4">
+    <h3>Signin Settings <button class="btn btn-primary pull-right" {{action 'saveSigninSettings'}}>Save Sign In Settings</button></h3>
+    {{json-editor json=signinSettingsJson mode="code" onChange=(action (mut signinSettingsJson))}}
+    <h5>NOTE</h5>
+    <p>Auto Sign Up property does not work on non-community orgs</p>
   </div>
 </div>
 <div class="row">

--- a/tests/dummy/app/portal/template.hbs
+++ b/tests/dummy/app/portal/template.hbs
@@ -49,8 +49,13 @@
   <div class="col-sm-4">
     <h3>Signin Settings <button class="btn btn-primary pull-right" {{action 'saveSigninSettings'}}>Save Sign In Settings</button></h3>
     {{json-editor json=signinSettingsJson mode="code" onChange=(action (mut signinSettingsJson))}}
-    <h5>NOTE</h5>
-    <p>Auto Sign Up property does not work on non-community orgs</p>
+    <h5>Example</h5>
+    <p>enableArcGISAutoSignups only avail. on community orgs</p>
+    <pre>
+      <code>
+{{signinSettingsExample}}
+      </code>
+    </pre>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
The ArcGIS Online platform made signinSettings available in 7.1. This extends the dummy app to allow power users to modify their signin settings directly against portal.

![image](https://user-images.githubusercontent.com/5465514/61487821-c9e46600-a974-11e9-91f5-3a669a3df8e0.png)

adds signinSettings to the dummy app for easy editing