### PR TITLE
Fix brackets in query string

### DIFF
--- a/addon/services/groups-service.js
+++ b/addon/services/groups-service.js
@@ -345,7 +345,7 @@ export default Service.extend(serviceMixin, {
     }
 
     return orgIdPromise
-    .then(orgId => ({ q: `title:"(${title}" accountid:${orgId})` }))
+    .then(orgId => ({ q: `(title:"${title}" accountid:${orgId})` }))
     .then(query => {
       return this.search(query, portalOpts);
     })


### PR DESCRIPTION
`groupsService.doesGroupExist` had a typo in the query string - a bracket was in the wrong location:

```
// incorrect
.then(orgId => ({ q: `title:"(${title}" accountid:${orgId})` }))
// correct
.then(orgId => ({ q: `(title:"${title}" accountid:${orgId})` }))
```

Net result was that it would never return true. This was not an issue that I can tell because we use gating in other locations to prevent the creation of initiatives/sites if a group with this intended name exists.