### PR TITLE
Create/update groups will now allow thumbnail binary to get through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Allow thumbnail blobs to be included in `update` and `create` in `groups-service`
 ## 2.6.0
 ### Added
 - `removeSocialProviders` call to `portal-service` to remove social providers

--- a/addon/services/groups-service.js
+++ b/addon/services/groups-service.js
@@ -79,8 +79,8 @@ export default Service.extend(serviceMixin, {
    */
   create (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
-    // JSON parse / json stringify utterly mucks up the thumbnail object so...
-    if (group.thumbnail) {
+    // cloning can't handle Blobs, so we pass the thumbnail property forward
+    if (typeof Blob !== "undefined" && group.thumbnail instanceof Blob) {
       clonedGroup.thumbnail = group.thumbnail;
     }
 
@@ -99,8 +99,8 @@ export default Service.extend(serviceMixin, {
    */
   update (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
-    // JSON parse / json stringify utterly mucks up the thumbnail object so...
-    if (group.thumbnail) {
+    // cloning can't handle Blobs, so we pass the thumbnail property forward
+    if (typeof Blob !== "undefined" && group.thumbnail instanceof Blob) {
       clonedGroup.thumbnail = group.thumbnail;
     }
 

--- a/addon/services/groups-service.js
+++ b/addon/services/groups-service.js
@@ -79,6 +79,10 @@ export default Service.extend(serviceMixin, {
    */
   create (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
+    // JSON parse / json stringify utterly mucks up the thumbnail object so...
+    if (group.thumbnail) {
+      clonedGroup.thumbnail = group.thumbnail;
+    }
 
     // noticed this in the dummy app, hoping its not _too_ common
     if (group.tags && typeof group.tags === 'string') {
@@ -95,6 +99,10 @@ export default Service.extend(serviceMixin, {
    */
   update (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
+    // JSON parse / json stringify utterly mucks up the thumbnail object so...
+    if (group.thumbnail) {
+      clonedGroup.thumbnail = group.thumbnail;
+    }
 
     if (group.tags && typeof group.tags === 'string') {
       clonedGroup.tags = this._cleanupTags(group.tags);

--- a/addon/services/groups-service.js
+++ b/addon/services/groups-service.js
@@ -80,7 +80,7 @@ export default Service.extend(serviceMixin, {
   create (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
     // cloning can't handle Blobs, so we pass the thumbnail property forward
-    if (typeof Blob !== "undefined" && group.thumbnail instanceof Blob) {
+    if (typeof Blob !== 'undefined' && group.thumbnail instanceof Blob) {
       clonedGroup.thumbnail = group.thumbnail;
     }
 
@@ -100,7 +100,7 @@ export default Service.extend(serviceMixin, {
   update (group, portalOpts) {
     let clonedGroup = JSON.parse(JSON.stringify(group));
     // cloning can't handle Blobs, so we pass the thumbnail property forward
-    if (typeof Blob !== "undefined" && group.thumbnail instanceof Blob) {
+    if (typeof Blob !== 'undefined' && group.thumbnail instanceof Blob) {
       clonedGroup.thumbnail = group.thumbnail;
     }
 


### PR DESCRIPTION
JSON.parse/JSON.stringify nukes the object/binary for the thumbnail prop that is needed in the request to the AGO groups service. This gets around that.