### PR TITLE
B/101433 create survey fails using duplicate title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 ### Changed
+- Refactored folderService folderExists method to be case insensitive to prevent error when creating create method [101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)
 ### Fixed
 ### Removed
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 ### Changed
-- Refactored folderService folderExists method to be case insensitive to prevent error when creating create method [101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)
+- Refactor folderService folderExists method to be case insensitive to prevent error when creating create method [101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)
 ### Fixed
 ### Removed
 ### Breaking

--- a/addon/services/folders-service.js
+++ b/addon/services/folders-service.js
@@ -18,17 +18,10 @@ export default Service.extend(serviceMixin, {
    * Check if a folder already exists...
    */
   folderExists (folderTitle, username, portalOpts) {
-    return this.getUserFolders(username, portalOpts)
-      .then((folders) => {
-        let match = folders.find((folder) => {
-          return folder.title === folderTitle;
-        });
-        if (match) {
-          return true;
-        } else {
-          return false;
-        }
-      });
+    const folderTitleLower = folderTitle.toLowerCase();
+    const caseInsensitiveTitleExists = ({ title }) => title.toLowerCase() === folderTitleLower;
+    const folderExists = folders => folders.some(caseInsensitiveTitleExists);
+    return this.getUserFolders(username, portalOpts).then(folderExists);
   },
 
   /**

--- a/addon/services/folders-service.js
+++ b/addon/services/folders-service.js
@@ -20,8 +20,8 @@ export default Service.extend(serviceMixin, {
   folderExists (folderTitle, username, portalOpts) {
     const folderTitleLower = folderTitle.toLowerCase();
     const caseInsensitiveTitleExists = ({ title }) => title.toLowerCase() === folderTitleLower;
-    const folderExists = folders => folders.some(caseInsensitiveTitleExists);
-    return this.getUserFolders(username, portalOpts).then(folderExists);
+    const folderTitleExists = folders => folders.some(caseInsensitiveTitleExists);
+    return this.getUserFolders(username, portalOpts).then(folderTitleExists);
   },
 
   /**


### PR DESCRIPTION
[101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)

The `folderService` `create` method throws an error if you try to create a new folder with the same name as a pre-existing folder with using different character casing. This PR refactors the `folderService` `folderExists` method to be case-insensitive to be better aligned with the `create` method.