### PR TITLE
106911 - Refactor addResource method to accept an additional, optiona…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 ### Changed
-- Refactor folderService folderExists method to be case insensitive to prevent error when creating create method [101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)
 ### Fixed
 ### Removed
 ### Breaking
+
+## 2.6.4
+### Changed
+- Refactor items-service addResource to accept an optional 6th argument that allows for additional params [106911](https://esriarlington.tpondemand.com/entity/106911-update-survey-service-to-account-for)
+
+## 2.6.3
+### Changed
+- Refactor folderService folderExists method to be case insensitive to prevent error when creating create method [101433](https://esriarlington.tpondemand.com/entity/101433-creating-survey-with-name-that-already)
 
 ## 2.6.2
 ### Changed

--- a/addon/services/items-service.js
+++ b/addon/services/items-service.js
@@ -196,14 +196,14 @@ export default Service.extend(serviceMixin, {
   /**
    * Add a resource
    */
-  addResource (itemId, owner, name, content, portalOpts) {
+  addResource (itemId, owner, name, content, portalOpts, addl = {}) {
     const urlPath = `/content/users/${owner}/items/${itemId}/addResources?f=json`;
     const options = {
       method: 'POST',
-      data: {
+      data: Object.assign(addl, {
         fileName: name,
         text: content
-      }
+      })
     };
     return this.request(urlPath, options, portalOpts);
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-arcgis-portal-services",
-  "version": "2.6.2",
+  "version": "2.6.4",
   "description": "A set of promise-based Ember Services for working with the ArcGIS Portal API.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
…l Object argument allowing for more parameters

[106911](https://esriarlington.tpondemand.com/entity/106911-update-survey-service-to-account-for)

This PR refactors the `items-service` `addResource` method to accept an optional, 6th parameter of type `Object`, allowing for additional parameters to be passed. Survey123 now stores form questions/theme data in the Feature Service resources, and we need to provide the `resourcesPrefix` property on the request